### PR TITLE
Bugfix/40674 expand oid range

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -234,6 +234,8 @@ func (x *GoSNMP) GetNext(oid string) (*SnmpPacket, error) {
 		}
 	}()
 
+	_ = err // Workaround for the unused variable problem
+
 	// Create the packet
 	packet := new(SnmpPacket)
 
@@ -267,6 +269,8 @@ func (x *GoSNMP) GetBulk(nonRepeaters, maxRepetitions uint8, oids ...string) (*S
 		}
 	}()
 
+	_ = err // Workaround for the unused variable problem
+
 	// Create the packet
 	packet := new(SnmpPacket)
 
@@ -294,6 +298,8 @@ func (x *GoSNMP) Get(oid string) (*SnmpPacket, error) {
 		}
 	}()
 
+	_ = err // Workaround for the unused variable problem
+
 	// Create the packet
 	packet := new(SnmpPacket)
 
@@ -316,6 +322,8 @@ func (x *GoSNMP) GetMulti(oids []string) (*SnmpPacket, error) {
 			err = fmt.Errorf("%v", e)
 		}
 	}()
+
+	_ = err // Workaround for the unused variable problem
 
 	// Create the packet
 	packet := new(SnmpPacket)

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -226,15 +226,14 @@ func (x *GoSNMP) sendPacket(packet *SnmpPacket) (*SnmpPacket, error) {
 
 // GetNext sends an SNMP Get Next Request to the target. Returns the next
 // variable response from the OID given or an error
-func (x *GoSNMP) GetNext(oid string) (*SnmpPacket, error) {
-	var err error
+func (x *GoSNMP) GetNext(oid string) (*SnmpPacket, err error) {
+
 	defer func() {
 		if e := recover(); e != nil {
 			err = fmt.Errorf("%v", e)
 		}
 	}()
 
-	_ = err // Workaround for the unused variable problem
 
 	// Create the packet
 	packet := new(SnmpPacket)
@@ -261,15 +260,13 @@ func (x *GoSNMP) Debug(data []byte) (*SnmpPacket, error) {
 
 // GetBulk sends an SNMP BULK-GET request to the target. Returns a Variable with
 // the response or an error
-func (x *GoSNMP) GetBulk(nonRepeaters, maxRepetitions uint8, oids ...string) (*SnmpPacket, error) {
-	var err error
+func (x *GoSNMP) GetBulk(nonRepeaters, maxRepetitions uint8, oids ...string) (*SnmpPacket, err error) {
+
 	defer func() {
 		if e := recover(); e != nil {
 			err = fmt.Errorf("%v", e)
 		}
 	}()
-
-	_ = err // Workaround for the unused variable problem
 
 	// Create the packet
 	packet := new(SnmpPacket)
@@ -290,15 +287,13 @@ func (x *GoSNMP) GetBulk(nonRepeaters, maxRepetitions uint8, oids ...string) (*S
 
 // Get sends an SNMP GET request to the target. Returns a Variable with the
 // response or an error
-func (x *GoSNMP) Get(oid string) (*SnmpPacket, error) {
-	var err error
+func (x *GoSNMP) Get(oid string) (*SnmpPacket, err error) {
+
 	defer func() {
 		if e := recover(); e != nil {
 			err = fmt.Errorf("%v", e)
 		}
 	}()
-
-	_ = err // Workaround for the unused variable problem
 
 	// Create the packet
 	packet := new(SnmpPacket)
@@ -315,15 +310,13 @@ func (x *GoSNMP) Get(oid string) (*SnmpPacket, error) {
 
 // GetMulti sends an SNMP GET request to the target. Returns a Variable with the
 // response or an error
-func (x *GoSNMP) GetMulti(oids []string) (*SnmpPacket, error) {
-	var err error
+func (x *GoSNMP) GetMulti(oids []string) (*SnmpPacket, err error) {
+
 	defer func() {
 		if e := recover(); e != nil {
 			err = fmt.Errorf("%v", e)
 		}
 	}()
-
-	_ = err // Workaround for the unused variable problem
 
 	// Create the packet
 	packet := new(SnmpPacket)

--- a/helper.go
+++ b/helper.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 )
 
-func marshalObjectIdentifier(oid []int) (ret []byte, err error) {
+func marshalObjectIdentifier(oid []uint32) (ret []byte, err error) {
 	out := bytes.NewBuffer(make([]byte, 0, 128))
 	if len(oid) < 2 || oid[0] > 6 || oid[1] >= 40 {
 		return nil, errors.New("invalid object identifier")

--- a/packet.go
+++ b/packet.go
@@ -354,18 +354,20 @@ func oidToString(oid []int) (ret string) {
 
 func marshalOID(oid string) ([]byte, error) {
 	var err error
-
+	var oidUl uint64
+    
 	// Encode the oid
 	oid = strings.Trim(oid, ".")
 	oidParts := strings.Split(oid, ".")
-	oidBytes := make([]int, len(oidParts))
+	oidBytes := make([]uint32, len(oidParts))
 
 	// Convert the string OID to an array of integers
 	for i := 0; i < len(oidParts); i++ {
-		oidBytes[i], err = strconv.Atoi(oidParts[i])
+		oidUl, err = strconv.ParseUint(oidParts[i],10,32)
 		if err != nil {
 			return nil, fmt.Errorf("Unable to parse OID: %s\n", err.Error())
 		}
+		oidBytes[i] = uint32(oidUl)
 	}
 
 	mOid, err := marshalObjectIdentifier(oidBytes)


### PR DESCRIPTION
* Починена ошибка длинных OID чисел
* Добавлен обход ошибки возникающей для неиспользованных переменных.